### PR TITLE
Add custom dataset support

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,20 @@ python infer_folder.py --image-dir <folder> --class-name <category>
 ```
 This will save anomaly visualizations to `./results`.
 
+## Training on your own dataset
+If you have a small collection such as 20 normal images and 300 abnormal images,
+place them under `datasets/custom` as described in [docs/custom_dataset.md](docs/custom_dataset.md).
+You can then build the feature gallery by running:
+
+```bash
+python eval_WinCLIP.py \
+  --dataset custom \
+  --class-name custom \
+  --k-shot 20
+```
+
+This performs evaluation using the images in `datasets/custom/test/anomaly`.
+
 
 ## Results
 

--- a/datasets/__init__.py
+++ b/datasets/__init__.py
@@ -5,6 +5,7 @@ from loguru import logger
 from .dataset import CLIPDataset
 from .mvtec import load_mvtec, mvtec_classes
 from .visa import load_visa, visa_classes
+from .custom import load_custom, custom_classes
 
 
 mean_train = [0.48145466, 0.4578275, 0.40821073]
@@ -13,13 +14,13 @@ std_train = [0.26862954, 0.26130258, 0.27577711]
 load_function_dict = {
     'mvtec': load_mvtec,
     'visa': load_visa,
-
-
+    'custom': load_custom,
 }
 
 dataset_classes = {
     'mvtec': mvtec_classes,
     'visa': visa_classes,
+    'custom': custom_classes,
 }
 
 def denormalization(x):

--- a/datasets/custom.py
+++ b/datasets/custom.py
@@ -1,0 +1,65 @@
+import glob
+import os
+import random
+
+
+custom_classes = ["custom"]
+
+CUSTOM_DIR = "../datasets/custom"
+
+
+def _load_from_dir(folder, label):
+    """Load images from a directory.
+
+    Parameters
+    ----------
+    folder: str
+        Directory containing images.
+    label: int
+        0 for normal images, 1 for abnormal images.
+
+    Returns
+    -------
+    (list, list, list, list)
+        Image paths, dummy mask paths, labels and type strings.
+    """
+    if not os.path.isdir(folder):
+        return [], [], [], []
+
+    img_paths = sorted(glob.glob(os.path.join(folder, "*")))
+    gt_paths = [0 for _ in img_paths]
+    labels = [label for _ in img_paths]
+    types = ["good" if label == 0 else "anomaly" for _ in img_paths]
+    return img_paths, gt_paths, labels, types
+
+
+def load_custom(category, k_shot, experiment_indx):
+    """Load a simple folder based dataset.
+
+    The directory ``CUSTOM_DIR`` should contain::
+
+        train/good/      # normal images
+        test/anomaly/    # abnormal images for evaluation
+
+    Ground truth masks are optional. If not found, zero masks are used.
+    """
+
+    train_good = os.path.join(CUSTOM_DIR, "train", "good")
+    test_anomaly = os.path.join(CUSTOM_DIR, "test", "anomaly")
+
+    train_img_paths, train_gt_paths, train_labels, train_types = _load_from_dir(
+        train_good, 0)
+    test_img_paths, test_gt_paths, test_labels, test_types = _load_from_dir(
+        test_anomaly, 1)
+
+    if k_shot > 0 and len(train_img_paths) > k_shot:
+        random.seed(experiment_indx)
+        indices = random.sample(range(len(train_img_paths)), k_shot)
+        train_img_paths = [train_img_paths[i] for i in indices]
+        train_gt_paths = [train_gt_paths[i] for i in indices]
+        train_labels = [train_labels[i] for i in indices]
+        train_types = [train_types[i] for i in indices]
+
+    return (train_img_paths, train_gt_paths, train_labels, train_types), \
+           (test_img_paths, test_gt_paths, test_labels, test_types)
+

--- a/datasets/dataset.py
+++ b/datasets/dataset.py
@@ -12,7 +12,7 @@ class CLIPDataset(Dataset):
         self.load_function = load_function
         self.phase = phase
 
-        assert k_shot in [0, 1, 5, 10]
+        assert k_shot >= 0
         assert experiment_indx in [0, 1, 2]
 
         self.category = category

--- a/datasets/mvtec.py
+++ b/datasets/mvtec.py
@@ -41,7 +41,7 @@ def load_mvtec(category, k_shot, experiment_indx):
         return img_tot_paths, gt_tot_paths, tot_labels, tot_types
 
     assert category in mvtec_classes
-    assert k_shot in [0, 1, 5, 10]
+    assert k_shot >= 0
     assert experiment_indx in [0, 1, 2]
 
     test_img_path = os.path.join(MVTEC2D_DIR, category, 'test')

--- a/datasets/visa.py
+++ b/datasets/visa.py
@@ -41,7 +41,7 @@ def load_visa(category, k_shot, experiment_indx):
         return img_tot_paths, gt_tot_paths, tot_labels, tot_types
 
     assert category in visa_classes
-    assert k_shot in [0, 1, 5, 10]
+    assert k_shot >= 0
     assert experiment_indx in [0, 1, 2]
 
     test_img_path = os.path.join(VISA_DIR, category, 'test')

--- a/docs/custom_dataset.md
+++ b/docs/custom_dataset.md
@@ -1,0 +1,23 @@
+# 独自データセットでの学習
+
+20 枚の正常画像と 300 枚の異常画像のように，小規模なデータを用いて特徴ギャラリーを生成する場合は `datasets/custom` ディレクトリに以下の構成で画像を配置します。
+
+```
+datasets/custom/
+  train/
+    good/      # 正常画像 (20 枚)
+  test/
+    anomaly/   # 異常画像 (300 枚)
+```
+
+`eval_WinCLIP.py` で `--dataset custom` を指定するとこのフォルダ構造を読み込みます。`--k-shot` には使用する正常画像枚数を設定できます。
+
+```bash
+python eval_WinCLIP.py \
+  --dataset custom \
+  --class-name custom \
+  --k-shot 20 \
+  --gpu-id 0
+```
+
+これにより 20 枚の正常画像からギャラリーを生成し，300 枚の異常画像で評価を行います。


### PR DESCRIPTION
## Summary
- allow arbitrary k-shot values
- support a simple folder-based custom dataset
- document how to train with a small dataset

## Testing
- `python -m py_compile WinClip/datasets/custom.py WinClip/datasets/__init__.py WinClip/datasets/dataset.py WinClip/datasets/mvtec.py WinClip/datasets/visa.py`

------
https://chatgpt.com/codex/tasks/task_e_686e804d0f108333b521f4650c16ee2a