### PR TITLE
Fix dataset loader returns and add custom dataset constant

### DIFF
--- a/datasets/__init__.py
+++ b/datasets/__init__.py
@@ -54,3 +54,5 @@ def get_dataloader_from_args(phase, **kwargs):
     debug_str = f"===> datasets: {kwargs['dataset']}, class name/len: {kwargs['class_name']}/{len(dataset_inst)}, batch size: {kwargs['batch_size']}"
     logger.info(debug_str)
 
+    return data_loader, dataset_inst
+

--- a/datasets/custom.py
+++ b/datasets/custom.py
@@ -2,6 +2,9 @@ import glob
 import os
 import random
 
+# Base directory for custom dataset
+CUSTOM_DIR = os.path.join(os.path.dirname(__file__), "custom")
+
 
 custom_classes = ["custom"]
 


### PR DESCRIPTION
## Summary
- fix missing return in `get_dataloader_from_args`
- define `CUSTOM_DIR` for the simple custom dataset

## Testing
- `python3 eval_WinCLIP.py --dataset custom --class-name custom --k-shot 20 --gpu-id 0` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686e87ddbbf083339cb8bf3e9979cc62